### PR TITLE
Pool 2741 prizepoolgetvaultportion not working correctly

### DIFF
--- a/test/libraries/DrawAccumulatorLib.t.sol
+++ b/test/libraries/DrawAccumulatorLib.t.sol
@@ -136,19 +136,6 @@ contract DrawAccumulatorLibTest is Test {
         assertEq(getDisbursedBetween(2, 4), 2438);
     }
 
-    function testGetDisbursedBetween_beforeTwo() public {
-        add(3);
-        add(5);
-        /*
-            should include draw 1, 2, 3 and 4:
-            3	    1000
-            4		900
-            5		810 + 1000
-            6		729 + 900
-        */
-        assertEq(getDisbursedBetween(1, 4), 1899);
-    }
-
     function testGetDisbursedBetween_beforeOnTwo() public {
         add(4);
         add(5);


### PR DESCRIPTION
### Summary

There was misbehavior in the `getVaultPortion` function due to a mismatch in interface design between internal and external functions.

### Changes

- Removed a redundant test for `DrawAccumulatorLib` (cdb43efc52696caf4c01e08fe46853db467791ed)
- Added developer documentation for the limitations of `_endDrawId` for `getDisbursedBetween` (2062a189edb93e45159cb18fe6e6b5d0149fe773)
- Updated `getVaultPortion` interface and add unit tests to verify that the previous issues are resolved with the interface update (425050a405e4c61539de0a08ec62329f91d637d1)