### PR TITLE
Update TieredLiquidityDistributor Invariant test to use all tiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ docs/
 
 # Coverage
 lcov.info
+
+# Test Output Data
+data/

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,4 +3,5 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 gas_reports_ignore = ["ERC20Mintable", "TwabController"]
+fs_permissions = [{ access = "read-write", path = "./data"}]
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/test/invariants/TieredLiquidityDistributorInvariants.t.sol
+++ b/test/invariants/TieredLiquidityDistributorInvariants.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
 import "forge-std/console2.sol";
-import { UD60x18, toUD60x18 } from "prb-math/UD60x18.sol";
+import { UD60x18, toUD60x18, fromUD60x18 } from "prb-math/UD60x18.sol";
 
 import { TieredLiquidityDistributorFuzzHarness } from "./helpers/TieredLiquidityDistributorFuzzHarness.sol";
 
@@ -57,7 +57,7 @@ contract TieredLiquidityDistributorInvariants is Test {
     function expectedLiquidityDeltaRange(uint8 numberOfTiers) internal pure returns(uint256) {
         require(numberOfTiers >= 2, "DeltaRange/number of tiers too low");
         UD60x18 slope = toUD60x18(10).div(toUD60x18(13));
-        return 8 + UD60x18.unwrap(slope.mul(toUD60x18(numberOfTiers - 2)).ceil()) / 1e18;
+        return 8 + fromUD60x18(slope.mul(toUD60x18(numberOfTiers - 2)).ceil());
     }
 
     // Tests for the helper function

--- a/test/invariants/TieredLiquidityDistributorInvariants.t.sol
+++ b/test/invariants/TieredLiquidityDistributorInvariants.t.sol
@@ -18,4 +18,23 @@ contract TieredLiquidityDistributorInvariants is Test {
         uint256 expected = distributor.totalAdded() - distributor.totalConsumed();
         assertApproxEqAbs(distributor.accountedLiquidity(), expected, 7);
     }
+
+    function testInvariantFailure_Case_26_05_2023() external {
+        distributor.nextDraw(3, 253012247290373118207);
+        distributor.nextDraw(2, 99152290762372054017);
+        distributor.nextDraw(255, 79228162514264337593543950333);
+        distributor.consumeLiquidity(1);
+        distributor.consumeLiquidity(0);
+        distributor.nextDraw(0, 2365);
+        distributor.nextDraw(4, 36387);
+        distributor.nextDraw(73, 486356342973499764);
+        distributor.consumeLiquidity(174);
+        distributor.consumeLiquidity(254);
+        distributor.nextDraw(5, 2335051495798885129312);
+        distributor.nextDraw(159, 543634559793817062402422965);
+        distributor.nextDraw(186, 3765046993999626249);
+        distributor.nextDraw(0, 196958881398058173458);
+        uint256 expected = distributor.totalAdded() - distributor.totalConsumed();
+        assertApproxEqAbs(distributor.accountedLiquidity(), expected, 7);
+    }
 }

--- a/test/invariants/helpers/TieredLiquidityDistributorFuzzHarness.sol
+++ b/test/invariants/helpers/TieredLiquidityDistributorFuzzHarness.sol
@@ -16,7 +16,7 @@ contract TieredLiquidityDistributorFuzzHarness is TieredLiquidityDistributor {
         uint8 nextNumTiers = _nextNumTiers / 16; // map to [0, 15]
         nextNumTiers = nextNumTiers < 2 ? 2 : nextNumTiers; // ensure min tiers
         totalAdded += liquidity;
-        _nextDraw(2, liquidity);
+        _nextDraw(nextNumTiers, liquidity);
     }
 
     function net() external view returns (uint256) {


### PR DESCRIPTION
### Background

Background information can be found on the [pool-2755 linear ticket comments](https://linear.app/pooltogether/issue/POOL-2755/prize-pool-invarianttiersalwayssum-test-failure).

### Summary

The `TieredLiquidityDistributorFuzzHarness.nextDraw` function was using a hard-coded value for the number of tiers to use on the next draw instead of the random value provided in the function. This was preventing the invariant test from running on all the possible tier combinations.

These changes fix that function and add countermeasures to keep the test as accurate as possible. By allowing more tiers to be used in the test, our test delta value is expected to increase somewhat linearly with the amount of tiers used due to an increase number of calculations with the liquidity. After running some tests and recording the data, this varies from a max delta of `7` for 2 tiers and a max delta of `16` for 15 tiers (as seen in the below chart). To ensure that we accurately test all cases, a variable delta ceiling was applied based on the current number of tiers being tested (the `custom_fit_ceil` line).

![image](https://github.com/pooltogether/v5-prize-pool/assets/40277611/1b5fede0-746b-4b5e-9433-f69d50334070)

### Other Changes

The original test failure scenario has also been added for regression testing (2a91abe33df58500c15ddf2e00b09c39ee0e34f2).