### PR TITLE
Add missed draw skipping with dynamic nextDrawId

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -303,7 +303,7 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
         uint16 nextDrawId_ = _nextDrawId();
         uint64 nextDrawStartsAt_ = _nextDrawStartsAt();
 
-        _nextDraw(nextNumberOfTiers, uint96(_contributionsForDraw(nextDrawId_)), _nextDrawId());
+        _nextDraw(nextNumberOfTiers, uint96(_contributionsForDraw(nextDrawId_)), nextDrawId_);
 
         _winningRandomNumber = winningRandomNumber_;
         claimCount = 0;

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -245,7 +245,7 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
         }
     }
 
-    /// @notice Returns the time at which the next draw end.
+    /// @notice Returns the time at which the next draw ends.
     function _nextDrawEndsAt() internal view returns (uint64) {
         if (lastCompletedDrawId != 0) {
             uint16 drawsSinceCompleted = _nextDrawId() - lastCompletedDrawId;
@@ -258,7 +258,7 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
     /// @notice Returns the next draw ID, ignoring missed draws.
     function _nextDrawId() internal view returns (uint16) {
         if(lastCompletedDrawId == 0) {
-            return lastCompletedDrawId + 1;
+            return 1;
         } else {
             uint64 timeSinceLastStart = uint64(block.timestamp - lastCompletedDrawStartedAt_);
             if(timeSinceLastStart < drawPeriodSeconds * 2) {

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -150,8 +150,9 @@ contract TieredLiquidityDistributor {
     /// @notice Adjusts the number of tiers and distributes new liquidity
     /// @param _nextNumberOfTiers The new number of tiers. Must be greater than minimum
     /// @param _prizeTokenLiquidity The amount of fresh liquidity to distribute across the tiers and reserve
-    function _nextDraw(uint8 _nextNumberOfTiers, uint96 _prizeTokenLiquidity, uint16 completedDrawId) internal {
-        require(completedDrawId > lastCompletedDrawId, "already completed");
+    /// @param _completedDrawId The ID of the draw to complete
+    function _nextDraw(uint8 _nextNumberOfTiers, uint96 _prizeTokenLiquidity, uint16 _completedDrawId) internal {
+        require(_completedDrawId > lastCompletedDrawId, "already completed");
         if(_nextNumberOfTiers < MINIMUM_NUMBER_OF_TIERS) {
             revert NumberOfTiersLessThanMinimum(_nextNumberOfTiers);
         }
@@ -164,7 +165,7 @@ contract TieredLiquidityDistributor {
         if (_nextNumberOfTiers > numTiers) {
             for (uint8 i = numTiers; i < _nextNumberOfTiers; i++) {
                 _tiers[i] = Tier({
-                    drawId: completedDrawId,
+                    drawId: _completedDrawId,
                     prizeTokenPerShare: prizeTokenPerShare,
                     prizeSize: uint96(_computePrizeSize(i, _nextNumberOfTiers, _prizeTokenPerShare, newPrizeTokenPerShare))
                 });
@@ -173,14 +174,14 @@ contract TieredLiquidityDistributor {
 
         // Set canary tier
         _tiers[_nextNumberOfTiers] = Tier({
-            drawId: completedDrawId,
+            drawId: _completedDrawId,
             prizeTokenPerShare: prizeTokenPerShare,
             prizeSize: uint96(_computePrizeSize(_nextNumberOfTiers, _nextNumberOfTiers, _prizeTokenPerShare, newPrizeTokenPerShare))
         });
 
         prizeTokenPerShare = fromUD60x18toUD34x4(newPrizeTokenPerShare);
         numberOfTiers = _nextNumberOfTiers;
-        lastCompletedDrawId = completedDrawId;
+        lastCompletedDrawId = _completedDrawId;
         _reserve += newReserve;
     }
 

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -244,6 +244,37 @@ contract PrizePoolTest is Test {
         assertEq(nextDrawId, 1);
     }
 
+    function testGetNextDrawId_NotFirst() public {
+        vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds); // at draw period 2
+        prizePool.completeAndStartNextDraw(winningRandomNumber);
+        uint256 nextDrawId = prizePool.getNextDrawId();
+        assertEq(nextDrawId, 2);
+    }
+
+    function testGetNextDrawId_MissedDraw() public {
+        vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds); // at draw period 2
+        prizePool.completeAndStartNextDraw(winningRandomNumber);
+        vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds + drawPeriodSeconds + drawPeriodSeconds); // at draw period 4
+        uint256 nextDrawId = prizePool.getNextDrawId();
+        assertEq(nextDrawId, 3);
+    }
+
+    function testGetNextDrawId_MissedDraw_MiddleOfPeriod() public {
+        vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds); // at draw period 2
+        prizePool.completeAndStartNextDraw(winningRandomNumber);
+        vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds + drawPeriodSeconds + drawPeriodSeconds + drawPeriodSeconds / 2); // in middle of draw period 4
+        uint256 nextDrawId = prizePool.getNextDrawId();
+        assertEq(nextDrawId, 3);
+    }
+
+    function testGetNextDrawId_Missed2Draw() public {
+        vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds); // at draw period 2
+        prizePool.completeAndStartNextDraw(winningRandomNumber);
+        vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds + drawPeriodSeconds + drawPeriodSeconds + drawPeriodSeconds); // at draw period 5
+        uint256 nextDrawId = prizePool.getNextDrawId();
+        assertEq(nextDrawId, 4);
+    }
+
     function testCompleteAndStartNextDraw_notElapsed_atStart() public {
         vm.warp(lastCompletedDrawStartedAt);
         vm.expectRevert("not elapsed");

--- a/test/abstract/TieredLiquidityDistributor.t.sol
+++ b/test/abstract/TieredLiquidityDistributor.t.sol
@@ -35,44 +35,44 @@ contract TieredLiquidityDistributorTest is Test {
 
     function testNextDraw_invalid_num_tiers() public {
         vm.expectRevert(abi.encodeWithSelector(NumberOfTiersLessThanMinimum.selector, 1));
-        distributor.nextDraw(1, 100);
+        distributor.nextDraw(1, 100, 1);
     }
 
     function testRemainingTierLiquidity() public {
-        distributor.nextDraw(2, 220e18);
+        distributor.nextDraw(2, 220e18, 1);
         assertEq(distributor.remainingTierLiquidity(0), 100e18);
         assertEq(distributor.remainingTierLiquidity(1), 100e18);
         assertEq(distributor.remainingTierLiquidity(2), 10e18);
     }
 
     function testConsumeLiquidity_partial() public {
-        distributor.nextDraw(2, 220e18);
+        distributor.nextDraw(2, 220e18, 1);
         distributor.consumeLiquidity(1, 50e18); // consume full liq for tier 1
         assertEq(distributor.remainingTierLiquidity(1), 50e18);
     }
 
     function testConsumeLiquidity_full() public {
-        distributor.nextDraw(2, 220e18);
+        distributor.nextDraw(2, 220e18, 1);
         distributor.consumeLiquidity(1, 100e18); // consume full liq for tier 1
         assertEq(distributor.remainingTierLiquidity(1), 0);
     }
 
     function testConsumeLiquidity_and_empty_reserve() public {
-        distributor.nextDraw(2, 220e18); // reserve should be 10e18
+        distributor.nextDraw(2, 220e18, 1); // reserve should be 10e18
         distributor.consumeLiquidity(1, 110e18); // consume full liq for tier 1 and reserve
         assertEq(distributor.remainingTierLiquidity(1), 0);
         assertEq(distributor.reserve(), 0);
     }
 
     function testConsumeLiquidity_and_partial_reserve() public {
-        distributor.nextDraw(2, 220e18); // reserve should be 10e18
+        distributor.nextDraw(2, 220e18, 1); // reserve should be 10e18
         distributor.consumeLiquidity(1, 105e18); // consume full liq for tier 1 and reserve
         assertEq(distributor.remainingTierLiquidity(1), 0);
         assertEq(distributor.reserve(), 5e18);
     }
 
     function testConsumeLiquidity_insufficient() public {
-        distributor.nextDraw(2, 220e18); // reserve should be 10e18
+        distributor.nextDraw(2, 220e18, 1); // reserve should be 10e18
         vm.expectRevert(abi.encodeWithSelector(InsufficientLiquidity.selector, 120e18));
         distributor.consumeLiquidity(1, 120e18);
     }

--- a/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
+++ b/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
@@ -15,8 +15,8 @@ contract TieredLiquidityDistributorWrapper is TieredLiquidityDistributor {
         uint8 _reserveShares
     ) TieredLiquidityDistributor(_grandPrizePeriodDraws, _numberOfTiers, _tierShares, _canaryShares, _reserveShares) {}
 
-    function nextDraw(uint8 _nextNumTiers, uint96 liquidity) external {
-        _nextDraw(_nextNumTiers, liquidity);
+    function nextDraw(uint8 _nextNumTiers, uint96 liquidity, uint16 nextDrawId) external {
+        _nextDraw(_nextNumTiers, liquidity, nextDrawId);
     }
 
     function consumeLiquidity(uint8 _tier, uint104 _liquidity) external returns (Tier memory) {

--- a/test/invariants/TieredLiquidityDistributorInvariants.t.sol
+++ b/test/invariants/TieredLiquidityDistributorInvariants.t.sol
@@ -32,20 +32,20 @@ contract TieredLiquidityDistributorInvariants is Test {
 
     // Failure case regression test (2023-05-26)
     function testInvariantFailure_Case_2023_05_26() external {
-        distributor.nextDraw(3, 253012247290373118207);
-        distributor.nextDraw(2, 99152290762372054017);
-        distributor.nextDraw(255, 79228162514264337593543950333);
+        distributor.nextDraw(3, 253012247290373118207, 1);
+        distributor.nextDraw(2, 99152290762372054017, 2);
+        distributor.nextDraw(255, 79228162514264337593543950333, 3);
         distributor.consumeLiquidity(1);
         distributor.consumeLiquidity(0);
-        distributor.nextDraw(0, 2365);
-        distributor.nextDraw(4, 36387);
-        distributor.nextDraw(73, 486356342973499764);
+        distributor.nextDraw(0, 2365, 4);
+        distributor.nextDraw(4, 36387, 5);
+        distributor.nextDraw(73, 486356342973499764, 6);
         distributor.consumeLiquidity(174);
         distributor.consumeLiquidity(254);
-        distributor.nextDraw(5, 2335051495798885129312);
-        distributor.nextDraw(159, 543634559793817062402422965);
-        distributor.nextDraw(186, 3765046993999626249);
-        distributor.nextDraw(0, 196958881398058173458);
+        distributor.nextDraw(5, 2335051495798885129312, 7);
+        distributor.nextDraw(159, 543634559793817062402422965, 8);
+        distributor.nextDraw(186, 3765046993999626249, 9);
+        distributor.nextDraw(0, 196958881398058173458, 10);
         uint256 expected = distributor.totalAdded() - distributor.totalConsumed();
         assertApproxEqAbs(distributor.accountedLiquidity(), expected, expectedLiquidityDeltaRange(distributor.numberOfTiers()));
     }

--- a/test/invariants/helpers/TieredLiquidityDistributorFuzzHarness.sol
+++ b/test/invariants/helpers/TieredLiquidityDistributorFuzzHarness.sol
@@ -12,11 +12,13 @@ contract TieredLiquidityDistributorFuzzHarness is TieredLiquidityDistributor {
 
     constructor () TieredLiquidityDistributor(10, 2, 100, 10, 10) {}
 
-    function nextDraw(uint8 _nextNumTiers, uint96 liquidity) external {
+    function nextDraw(uint8 _nextNumTiers, uint96 liquidity, uint16 nextDrawId) external {
         uint8 nextNumTiers = _nextNumTiers / 16; // map to [0, 15]
         nextNumTiers = nextNumTiers < 2 ? 2 : nextNumTiers; // ensure min tiers
         totalAdded += liquidity;
-        _nextDraw(nextNumTiers, liquidity);
+        if(nextDrawId <= lastCompletedDrawId) nextDrawId = lastCompletedDrawId + 1; // ensure always moving forward
+        if(nextDrawId > type(uint16).max / 2) nextDrawId = lastCompletedDrawId + 1; // ensure we don't exhaust our draw runway
+        _nextDraw(nextNumTiers, liquidity, nextDrawId);
     }
 
     function net() external view returns (uint256) {


### PR DESCRIPTION
## Purpose:

In the current implementation, if draws are missed because of insufficient reserve or some other external factor the prize pool will attempt to "catch up" to the current draw by completing all of the missed draws first. This is not desired behavior for "stagnant" pools that have experienced a large period of inactivity.

To fix this, the `nextDrawId` must be dynamic so that the prize pool can skip any draws that were not completed within their designated window. The new behavior of the prize pool is as follows:

- If the last draw, `n`, was completed as expected, then the next draw will be `n + 1` (this is the same behavior as before)
- If draw `n` is missed and the current time is in period `n + 2`, then the next draw will be `n + 1`
- If draw `n` is missed and the current time is in period `n + 3`, then the next draw will be `n + 2`
    - *Since the current timestamp is always one period ahead of the `nextDrawId`, we can be sure that the next draw will always be in the "finished" state. This ensures the prize pool can be immediately resumed when the draw agent is ready.*

## Notes:

- Since the next draw ID is now dependent on time and the prize pool's `drawPeriodSeconds` value, the `getNextDrawId` function has been moved from `TieredLiquidityDistributor.sol` to `PrizePool.sol`, and the `_nextDraw` function now accepts a `_completedDrawId` parameter so this information can be passed in.