### PR TITLE
Extend duration of next draw if period was missed

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -246,11 +246,12 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
 
     /// @notice Returns the time at which the next draw end.
     function _nextDrawEndsAt() internal view returns (uint64) {
-        if (lastCompletedDrawId != 0) {
-            return lastCompletedDrawStartedAt_ + 2 * drawPeriodSeconds;
-        } else {
-            return lastCompletedDrawStartedAt_ + drawPeriodSeconds;
+        uint64 nextExpectedEndTime = lastCompletedDrawStartedAt_ + (lastCompletedDrawId == 0 ? 1 : 2) * drawPeriodSeconds;
+        if (block.timestamp > nextExpectedEndTime) {
+            uint32 numMissedDraws = uint32((block.timestamp - nextExpectedEndTime) / drawPeriodSeconds);
+            nextExpectedEndTime += drawPeriodSeconds * numMissedDraws;
         }
+        return nextExpectedEndTime;
     }
 
     function _computeNextNumberOfTiers(uint8 _numTiers) internal view returns (uint8) {

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -644,7 +644,23 @@ contract PrizePoolTest is Test {
         assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt+drawPeriodSeconds);
     }
 
+    function testNextDrawIncludesMissedDraws() public {
+        assertEq(prizePool.getNextDrawId(), 1);
+        vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt);
+        assertEq(prizePool.nextDrawEndsAt(), lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        completeAndStartNextDraw(winningRandomNumber);
+        assertEq(prizePool.getNextDrawId(), 2);
+    }
 
+    function testNextDrawIncludesMissedDraws_middleOfDraw() public {
+        assertEq(prizePool.getNextDrawId(), 1);
+        vm.warp(lastCompletedDrawStartedAt + (drawPeriodSeconds * 5) / 2);
+        assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt);
+        assertEq(prizePool.nextDrawEndsAt(), lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        completeAndStartNextDraw(winningRandomNumber);
+        assertEq(prizePool.getNextDrawId(), 2);
+    }
 
     // function testCalculatePrizeSize() public {
     //     contribute(100e18);


### PR DESCRIPTION
## Summary

This changes the `_nextDrawEndsAt` function to extend the next draw's duration if it has not been completed in the expected time window. This ensures that a prize pool can become stagnant over a long period of time and pick up directly where it left off without skipping draw IDs or having to "catch up" with the current draw ID.

## Example

If draw 1 started at period 1, but hasn't been completed by the start of period 3, then it will be set to end at the end of period 2. If it still hasn't been completed by the start of period 4, then it's new end will be the end of period 3. And so on...

This ensures that if the prize pool has missed a period, the next draw period end time will never be older than 1 period from the current block time.