### PR TITLE
Extend duration of next draw if period was missed

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -250,11 +250,12 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
 
     /// @notice Returns the time at which the next draw end.
     function _nextDrawEndsAt() internal view returns (uint64) {
-        if (lastCompletedDrawId != 0) {
-            return lastCompletedDrawStartedAt_ + 2 * drawPeriodSeconds;
-        } else {
-            return lastCompletedDrawStartedAt_ + drawPeriodSeconds;
+        uint64 nextExpectedEndTime = lastCompletedDrawStartedAt_ + (lastCompletedDrawId == 0 ? 1 : 2) * drawPeriodSeconds;
+        if (block.timestamp > nextExpectedEndTime) {
+            uint32 numMissedDraws = uint32((block.timestamp - nextExpectedEndTime) / drawPeriodSeconds);
+            nextExpectedEndTime += drawPeriodSeconds * numMissedDraws;
         }
+        return nextExpectedEndTime;
     }
 
     function _computeNextNumberOfTiers(uint8 _numTiers) internal view returns (uint8) {

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -241,10 +241,13 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
 
     /// @notice Returns the start time of the draw for the next successful completeAndStartNextDraw
     function _nextDrawStartsAt() internal view returns (uint64) {
+        // If this is the first draw, we treat lastCompletedDrawStartedAt_ as the start of this draw
         uint64 nextExpectedStartTime = lastCompletedDrawStartedAt_ + (lastCompletedDrawId == 0 ? 0 : 1) * drawPeriodSeconds;
         uint64 nextExpectedEndTime = nextExpectedStartTime + drawPeriodSeconds;
         if (block.timestamp > nextExpectedEndTime) {
+            // Use integer division to get the number of draw periods passed since the expected end and now
             uint32 numMissedDraws = uint32((block.timestamp - nextExpectedEndTime) / drawPeriodSeconds);
+            // Offset the start time by the total duration of the missed draws
             nextExpectedStartTime += drawPeriodSeconds * numMissedDraws;
         }
         return nextExpectedStartTime;
@@ -252,9 +255,12 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
 
     /// @notice Returns the time at which the next draw end.
     function _nextDrawEndsAt() internal view returns (uint64) {
+        // If this is the first draw, we treat lastCompletedDrawStartedAt_ as the start of this draw
         uint64 nextExpectedEndTime = lastCompletedDrawStartedAt_ + (lastCompletedDrawId == 0 ? 1 : 2) * drawPeriodSeconds;
         if (block.timestamp > nextExpectedEndTime) {
+            // Use integer division to get the number of draw periods passed since the expected end and now
             uint32 numMissedDraws = uint32((block.timestamp - nextExpectedEndTime) / drawPeriodSeconds);
+            // Offset the end time by the total duration of the missed draws
             nextExpectedEndTime += drawPeriodSeconds * numMissedDraws;
         }
         return nextExpectedEndTime;

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -241,11 +241,13 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
 
     /// @notice Returns the start time of the draw for the next successful completeAndStartNextDraw
     function _nextDrawStartsAt() internal view returns (uint64) {
-        if (lastCompletedDrawId != 0) {
-            return lastCompletedDrawStartedAt_ + drawPeriodSeconds;
-        } else {
-            return lastCompletedDrawStartedAt_;
+        uint64 nextExpectedStartTime = lastCompletedDrawStartedAt_ + (lastCompletedDrawId == 0 ? 0 : 1) * drawPeriodSeconds;
+        uint64 nextExpectedEndTime = nextExpectedStartTime + drawPeriodSeconds;
+        if (block.timestamp > nextExpectedEndTime) {
+            uint32 numMissedDraws = uint32((block.timestamp - nextExpectedEndTime) / drawPeriodSeconds);
+            nextExpectedStartTime += drawPeriodSeconds * numMissedDraws;
         }
+        return nextExpectedStartTime;
     }
 
     /// @notice Returns the time at which the next draw end.

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -245,7 +245,7 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
         uint64 nextExpectedStartTime = lastCompletedDrawStartedAt_ + (lastCompletedDrawId == 0 ? 0 : 1) * drawPeriodSeconds;
         uint64 nextExpectedEndTime = nextExpectedStartTime + drawPeriodSeconds;
         if (block.timestamp > nextExpectedEndTime) {
-            // Use integer division to get the number of draw periods passed since the expected end and now
+            // Use integer division to get the number of draw periods passed between the expected end time and now
             uint32 numMissedDraws = uint32((block.timestamp - nextExpectedEndTime) / drawPeriodSeconds);
             // Offset the start time by the total duration of the missed draws
             nextExpectedStartTime += drawPeriodSeconds * numMissedDraws;
@@ -258,7 +258,7 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
         // If this is the first draw, we treat lastCompletedDrawStartedAt_ as the start of this draw
         uint64 nextExpectedEndTime = lastCompletedDrawStartedAt_ + (lastCompletedDrawId == 0 ? 1 : 2) * drawPeriodSeconds;
         if (block.timestamp > nextExpectedEndTime) {
-            // Use integer division to get the number of draw periods passed since the expected end and now
+            // Use integer division to get the number of draw periods passed between the expected end time and now
             uint32 numMissedDraws = uint32((block.timestamp - nextExpectedEndTime) / drawPeriodSeconds);
             // Offset the end time by the total duration of the missed draws
             nextExpectedEndTime += drawPeriodSeconds * numMissedDraws;

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -644,7 +644,23 @@ contract PrizePoolTest is Test {
         assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt+drawPeriodSeconds);
     }
 
+    function testNextDrawIncludesMissedDraws() public {
+        assertEq(prizePool.getNextDrawId(), 1);
+        vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt);
+        assertEq(prizePool.nextDrawEndsAt(), lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        completeAndStartNextDraw(winningRandomNumber);
+        assertEq(prizePool.getNextDrawId(), 2);
+    }
 
+    function testNextDrawIncludesMissedDraws_middleOfDraw() public {
+        assertEq(prizePool.getNextDrawId(), 1);
+        vm.warp(lastCompletedDrawStartedAt + (drawPeriodSeconds * 5) / 2);
+        assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt);
+        assertEq(prizePool.nextDrawEndsAt(), lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        completeAndStartNextDraw(winningRandomNumber);
+        assertEq(prizePool.getNextDrawId(), 2);
+    }
 
     // function testCalculatePrizeSize() public {
     //     contribute(100e18);

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -671,6 +671,42 @@ contract PrizePoolTest is Test {
         assertEq(prizePool.getNextDrawId(), 2);
     }
 
+    function testNextDrawIncludesMissedDraws_notFirstDraw() public {
+        completeAndStartNextDraw(winningRandomNumber);
+        uint64 _lastCompletedDrawStartedAt = prizePool.lastCompletedDrawStartedAt();
+        assertEq(prizePool.getNextDrawId(), 2);
+        vm.warp(_lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        assertEq(prizePool.nextDrawStartsAt(), _lastCompletedDrawStartedAt + drawPeriodSeconds);
+        assertEq(prizePool.nextDrawEndsAt(), _lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        completeAndStartNextDraw(winningRandomNumber);
+        assertEq(prizePool.getNextDrawId(), 3);
+    }
+
+    function testNextDrawIncludesMissedDraws_manyDrawsIn_manyMissed() public {
+        completeAndStartNextDraw(winningRandomNumber);
+        completeAndStartNextDraw(winningRandomNumber);
+        completeAndStartNextDraw(winningRandomNumber);
+        completeAndStartNextDraw(winningRandomNumber);
+        uint64 _lastCompletedDrawStartedAt = prizePool.lastCompletedDrawStartedAt();
+        assertEq(prizePool.getNextDrawId(), 5);
+        vm.warp(_lastCompletedDrawStartedAt + drawPeriodSeconds * 5);
+        assertEq(prizePool.nextDrawStartsAt(), _lastCompletedDrawStartedAt + drawPeriodSeconds * 4);
+        assertEq(prizePool.nextDrawEndsAt(), _lastCompletedDrawStartedAt + drawPeriodSeconds * 5);
+        completeAndStartNextDraw(winningRandomNumber);
+        assertEq(prizePool.getNextDrawId(), 6);
+    }
+
+    function testNextDrawIncludesMissedDraws_notFirstDraw_middleOfDraw() public {
+        completeAndStartNextDraw(winningRandomNumber);
+        uint64 _lastCompletedDrawStartedAt = prizePool.lastCompletedDrawStartedAt();
+        assertEq(prizePool.getNextDrawId(), 2);
+        vm.warp(_lastCompletedDrawStartedAt + (drawPeriodSeconds * 5) / 2);
+        assertEq(prizePool.nextDrawStartsAt(), _lastCompletedDrawStartedAt + drawPeriodSeconds);
+        assertEq(prizePool.nextDrawEndsAt(), _lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        completeAndStartNextDraw(winningRandomNumber);
+        assertEq(prizePool.getNextDrawId(), 3);
+    }
+
     // function testCalculatePrizeSize() public {
     //     contribute(100e18);
     //     prizePool.calculatePrizeSize();

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -647,7 +647,7 @@ contract PrizePoolTest is Test {
     function testNextDrawIncludesMissedDraws() public {
         assertEq(prizePool.getNextDrawId(), 1);
         vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
-        assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt);
+        assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt + drawPeriodSeconds);
         assertEq(prizePool.nextDrawEndsAt(), lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
         completeAndStartNextDraw(winningRandomNumber);
         assertEq(prizePool.getNextDrawId(), 2);
@@ -656,8 +656,17 @@ contract PrizePoolTest is Test {
     function testNextDrawIncludesMissedDraws_middleOfDraw() public {
         assertEq(prizePool.getNextDrawId(), 1);
         vm.warp(lastCompletedDrawStartedAt + (drawPeriodSeconds * 5) / 2);
-        assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt);
+        assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt + drawPeriodSeconds);
         assertEq(prizePool.nextDrawEndsAt(), lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        completeAndStartNextDraw(winningRandomNumber);
+        assertEq(prizePool.getNextDrawId(), 2);
+    }
+
+    function testNextDrawIncludesMissedDraws_2Draws() public {
+        assertEq(prizePool.getNextDrawId(), 1);
+        vm.warp(lastCompletedDrawStartedAt + drawPeriodSeconds * 3);
+        assertEq(prizePool.nextDrawStartsAt(), lastCompletedDrawStartedAt + drawPeriodSeconds * 2);
+        assertEq(prizePool.nextDrawEndsAt(), lastCompletedDrawStartedAt + drawPeriodSeconds * 3);
         completeAndStartNextDraw(winningRandomNumber);
         assertEq(prizePool.getNextDrawId(), 2);
     }


### PR DESCRIPTION
## Summary

This changes the `_nextDrawEndsAt` and `_nextDrawStartsAt` function to move the time window of the next draw if it has not been completed in the expected time window. This ensures that a prize pool can become stagnant over a long period of time and pick up directly where it left off without skipping draw IDs or having to "catch up" with the current draw ID.

## Example

If draw 1 started at period 1, but hasn't been completed by the start of period 3, then it will be set to end at the end of period 2. If it still hasn't been completed by the start of period 4, then it's new end will be the end of period 3. And so on...

This ensures that if the prize pool has missed a period, the next draw period end time will never be older than 1 period from the current block time.