### PR TITLE
Reduce Prize Pool Compiled Size

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -61,6 +61,7 @@ error SenderIsNotDrawManager(address sender, address drawManager);
  * @notice Constructor Parameters
  * @param prizeToken The token to use for prizes
  * @param twabController The Twab Controller retrieve time-weighted average balances from
+ * @param drawManager The address of the draw manager for the prize pool
  * @param grandPrizePeriodDraws The average number of draws between grand prizes. This determines the statistical frequency of grand prizes.
  * @param drawPeriodSeconds The number of seconds between draws. E.g. a Prize Pool with a daily draw should have a draw period of 86400 seconds.
  * @param firstDrawStartsAt The timestamp at which the first draw will start.
@@ -74,7 +75,7 @@ error SenderIsNotDrawManager(address sender, address drawManager);
 struct ConstructorParams {
     IERC20 prizeToken;
     TwabController twabController;
-    address _drawManager;
+    address drawManager;
     uint32 grandPrizePeriodDraws;
     uint32 drawPeriodSeconds;
     uint64 firstDrawStartsAt;
@@ -216,7 +217,7 @@ contract PrizePool is TieredLiquidityDistributor {
         }
         prizeToken = params.prizeToken;
         twabController = params.twabController;
-        drawManager = params._drawManager;
+        drawManager = params.drawManager;
         smoothing = params.smoothing;
         claimExpansionThreshold = params.claimExpansionThreshold;
         drawPeriodSeconds = params.drawPeriodSeconds;

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -7,8 +7,6 @@ import { E, SD59x18, sd, toSD59x18, fromSD59x18 } from "prb-math/SD59x18.sol";
 import { UD60x18, ud, toUD60x18, fromUD60x18, intoSD59x18 } from "prb-math/UD60x18.sol";
 import { UD2x18, intoUD60x18 } from "prb-math/UD2x18.sol";
 import { SD1x18, unwrap, UNIT } from "prb-math/SD1x18.sol";
-import { Manageable } from "owner-manager-contracts/Manageable.sol";
-import { Ownable } from "owner-manager-contracts/Ownable.sol";
 import { UD34x4, fromUD60x18 as fromUD60x18toUD34x4, intoUD60x18 as fromUD34x4toUD60x18, toUD34x4 } from "./libraries/UD34x4.sol";
 
 import { TwabController } from "v5-twab-controller/TwabController.sol";
@@ -56,12 +54,44 @@ error NoCompletedDraw();
 /// @notice Emitted when a tier does not exist
 error InvalidTier(uint8 tier, uint8 numberOfTiers);
 
+/// @notice Emitted when the sender is not the draw manager
+error SenderIsNotDrawManager(address sender, address drawManager);
+
+/**
+ * @notice Constructor Parameters
+ * @param prizeToken The token to use for prizes
+ * @param twabController The Twab Controller retrieve time-weighted average balances from
+ * @param grandPrizePeriodDraws The average number of draws between grand prizes. This determines the statistical frequency of grand prizes.
+ * @param drawPeriodSeconds The number of seconds between draws. E.g. a Prize Pool with a daily draw should have a draw period of 86400 seconds.
+ * @param firstDrawStartsAt The timestamp at which the first draw will start.
+ * @param numberOfTiers The number of tiers to start with. Must be greater than or equal to the minimum number of tiers.
+ * @param tierShares The number of shares to allocate to each tier
+ * @param canaryShares The number of shares to allocate to the canary tier.
+ * @param reserveShares The number of shares to allocate to the reserve.
+ * @param claimExpansionThreshold The percentage of prizes that must be claimed to bump the number of tiers. This threshold is used for both standard prizes and canary prizes.
+ * @param smoothing The amount of smoothing to apply to vault contributions. Must be less than 1. A value of 0 is no smoothing, while greater values smooth until approaching infinity
+ */
+struct ConstructorParams {
+    IERC20 prizeToken;
+    TwabController twabController;
+    address _drawManager;
+    uint32 grandPrizePeriodDraws;
+    uint32 drawPeriodSeconds;
+    uint64 firstDrawStartsAt;
+    uint8 numberOfTiers;
+    uint8 tierShares;
+    uint8 canaryShares;
+    uint8 reserveShares;
+    UD2x18 claimExpansionThreshold;
+    SD1x18 smoothing;
+}
+
 /**
  * @title PoolTogether V5 Prize Pool
  * @author PoolTogether Inc Team
  * @notice The Prize Pool holds the prize liquidity and allows vaults to claim prizes.
  */
-contract PrizePool is Manageable, TieredLiquidityDistributor {
+contract PrizePool is TieredLiquidityDistributor {
     using SafeERC20 for IERC20;
 
     using SafeERC20 for IERC20;
@@ -143,6 +173,9 @@ contract PrizePool is Manageable, TieredLiquidityDistributor {
     /// @notice The Twab Controller to use to retrieve historic balances.
     TwabController public immutable twabController;
 
+    /// @notice The draw manager address
+    address public immutable drawManager;
+
     /// @notice The number of seconds between draws
     uint32 public immutable drawPeriodSeconds;
 
@@ -173,43 +206,29 @@ contract PrizePool is Manageable, TieredLiquidityDistributor {
     /// @notice The timestamp at which the last completed draw was awarded
     uint64 internal _lastCompletedDrawAwardedAt;
 
-    /**
-     * @notice Constructs a new Prize Pool
-     * @param _prizeToken The token to use for prizes
-     * @param _twabController The Twab Controller retrieve time-weighted average balances from
-     * @param _grandPrizePeriodDraws The average number of draws between grand prizes. This determines the statistical frequency of grand prizes.
-     * @param _drawPeriodSeconds The number of seconds between draws. E.g. a Prize Pool with a daily draw should have a draw period of 86400 seconds.
-     * @param _firstDrawStartsAt The timestamp at which the first draw will start.
-     * @param _numberOfTiers The number of tiers to start with. Must be greater than or equal to the minimum number of tiers.
-     * @param _tierShares The number of shares to allocate to each tier
-     * @param _canaryShares The number of shares to allocate to the canary tier.
-     * @param _reserveShares The number of shares to allocate to the reserve.
-     * @param _claimExpansionThreshold The percentage of prizes that must be claimed to bump the number of tiers. This threshold is used for both standard prizes and canary prizes.
-     * @param _smoothing The amount of smoothing to apply to vault contributions. Must be less than 1. A value of 0 is no smoothing, while greater values smooth until approaching infinity
-     */
+    /// @notice Constructs a new Prize Pool
+    /// @param params A struct of constructor parameters
     constructor (
-        IERC20 _prizeToken,
-        TwabController _twabController,
-        uint32 _grandPrizePeriodDraws,
-        uint32 _drawPeriodSeconds,
-        uint64 _firstDrawStartsAt,
-        uint8 _numberOfTiers,
-        uint8 _tierShares,
-        uint8 _canaryShares,
-        uint8 _reserveShares,
-        UD2x18 _claimExpansionThreshold,
-        SD1x18 _smoothing
-    ) Ownable(msg.sender) TieredLiquidityDistributor(_grandPrizePeriodDraws, _numberOfTiers, _tierShares, _canaryShares, _reserveShares) {
-        prizeToken = _prizeToken;
-        twabController = _twabController;
-        smoothing = _smoothing;
-        claimExpansionThreshold = _claimExpansionThreshold;
-        drawPeriodSeconds = _drawPeriodSeconds;
-        _lastCompletedDrawStartedAt = _firstDrawStartsAt;
-
-        if(unwrap(_smoothing) >= unwrap(UNIT)) {
-            revert SmoothingGTEOne(unwrap(_smoothing));
+        ConstructorParams memory params
+    ) TieredLiquidityDistributor(params.grandPrizePeriodDraws, params.numberOfTiers, params.tierShares, params.canaryShares, params.reserveShares) {
+        if(unwrap(params.smoothing) >= unwrap(UNIT)) {
+            revert SmoothingGTEOne(unwrap(params.smoothing));
         }
+        prizeToken = params.prizeToken;
+        twabController = params.twabController;
+        drawManager = params._drawManager;
+        smoothing = params.smoothing;
+        claimExpansionThreshold = params.claimExpansionThreshold;
+        drawPeriodSeconds = params.drawPeriodSeconds;
+        _lastCompletedDrawStartedAt = params.firstDrawStartsAt;
+    }
+
+    /// @notice Modifier that throws if sender is not the draw manager
+    modifier onlyDrawManager() {
+        if(msg.sender != drawManager) {
+            revert SenderIsNotDrawManager(msg.sender, drawManager);
+        }
+        _;
     }
 
     /// @notice Returns the winning random number for the last completed draw
@@ -302,7 +321,7 @@ contract PrizePool is Manageable, TieredLiquidityDistributor {
     // @notice Allows the Manager to withdraw tokens from the reserve
     /// @param _to The address to send the tokens to
     /// @param _amount The amount of tokens to withdraw
-    function withdrawReserve(address _to, uint104 _amount) external onlyManager {
+    function withdrawReserve(address _to, uint104 _amount) external onlyDrawManager {
         if(_amount > _reserve) {
             revert InsufficientReserve(_amount, _reserve);
         }
@@ -367,7 +386,7 @@ contract PrizePool is Manageable, TieredLiquidityDistributor {
     /// @notice Allows the Manager to complete the current prize period and starts the next one, updating the number of tiers, the winning random number, and the prize pool reserve
     /// @param winningRandomNumber_ The winning random number for the current draw
     /// @return The ID of the completed draw
-    function completeAndStartNextDraw(uint256 winningRandomNumber_) external onlyManager returns (uint32) {
+    function completeAndStartNextDraw(uint256 winningRandomNumber_) external onlyDrawManager returns (uint32) {
         // check winning random number
         if (winningRandomNumber_ == 0) {
             revert RandomNumberIsZero();

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -329,18 +329,7 @@ contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
 
     /// @notice Returns the start time of the draw for the next successful completeAndStartNextDraw
     function _nextDrawStartsAt() internal view returns (uint64) {
-        // If this is the first draw, we treat _lastCompletedDrawStartedAt as the start of this draw
-        uint64 _nextExpectedStartTime = _lastCompletedDrawStartedAt + (lastCompletedDrawId == 0 ? 0 : 1) * drawPeriodSeconds;
-        uint64 _nextExpectedEndTime = _nextExpectedStartTime + drawPeriodSeconds;
-
-        if (block.timestamp > _nextExpectedEndTime) {
-            // Use integer division to get the number of draw periods passed between the expected end time and now
-            // Offset the start time by the total duration of the missed draws
-            // drawPeriodSeconds * numMissedDraws
-            _nextExpectedStartTime += drawPeriodSeconds * (uint32((block.timestamp - _nextExpectedEndTime) / drawPeriodSeconds));
-        }
-
-        return _nextExpectedStartTime;
+        return _nextDrawEndsAt() - drawPeriodSeconds;
     }
 
     /// @notice Returns the time at which the next draw end.

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.17;
 
 import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
-import { Multicall } from "openzeppelin/utils/Multicall.sol";
 import { E, SD59x18, sd, toSD59x18, fromSD59x18 } from "prb-math/SD59x18.sol";
 import { UD60x18, ud, toUD60x18, fromUD60x18, intoSD59x18 } from "prb-math/UD60x18.sol";
 import { UD2x18, intoUD60x18 } from "prb-math/UD2x18.sol";
@@ -62,7 +61,7 @@ error InvalidTier(uint8 tier, uint8 numberOfTiers);
  * @author PoolTogether Inc Team
  * @notice The Prize Pool holds the prize liquidity and allows vaults to claim prizes.
  */
-contract PrizePool is Manageable, Multicall, TieredLiquidityDistributor {
+contract PrizePool is Manageable, TieredLiquidityDistributor {
     using SafeERC20 for IERC20;
 
     using SafeERC20 for IERC20;

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -60,7 +60,7 @@ error SenderIsNotDrawManager(address sender, address drawManager);
 /**
  * @notice Constructor Parameters
  * @param prizeToken The token to use for prizes
- * @param twabController The Twab Controller retrieve time-weighted average balances from
+ * @param twabController The Twab Controller to retrieve time-weighted average balances from
  * @param drawManager The address of the draw manager for the prize pool
  * @param grandPrizePeriodDraws The average number of draws between grand prizes. This determines the statistical frequency of grand prizes.
  * @param drawPeriodSeconds The number of seconds between draws. E.g. a Prize Pool with a daily draw should have a draw period of 86400 seconds.

--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -54,8 +54,8 @@ error NoCompletedDraw();
 /// @notice Emitted when a tier does not exist
 error InvalidTier(uint8 tier, uint8 numberOfTiers);
 
-/// @notice Emitted when the sender is not the draw manager
-error SenderIsNotDrawManager(address sender, address drawManager);
+/// @notice Emitted when the caller is not the draw manager
+error CallerNotDrawManager(address caller, address drawManager);
 
 /**
  * @notice Constructor Parameters
@@ -227,7 +227,7 @@ contract PrizePool is TieredLiquidityDistributor {
     /// @notice Modifier that throws if sender is not the draw manager
     modifier onlyDrawManager() {
         if(msg.sender != drawManager) {
-            revert SenderIsNotDrawManager(msg.sender, drawManager);
+            revert CallerNotDrawManager(msg.sender, drawManager);
         }
         _;
     }

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -308,14 +308,25 @@ contract TieredLiquidityDistributor {
         assert(_tier <= _numberOfTiers);
         uint256 prizeSize;
         if (_prizeTokenPerShare.gt(_tierPrizeTokenPerShare)) {
-            UD60x18 delta = _prizeTokenPerShare.sub(_tierPrizeTokenPerShare);
             if (_tier == _numberOfTiers) {
-                prizeSize = fromUD60x18(delta.mul(toUD60x18(canaryShares)).div(_canaryPrizeCountFractional(_numberOfTiers)));
+                prizeSize = _computePrizeSize(_tierPrizeTokenPerShare, _prizeTokenPerShare, _canaryPrizeCountFractional(_numberOfTiers), canaryShares);
             } else {
-                prizeSize = fromUD60x18(delta.mul(toUD60x18(tierShares)).div(toUD60x18(TierCalculationLib.prizeCount(_tier))));
+                prizeSize = _computePrizeSize(_tierPrizeTokenPerShare, _prizeTokenPerShare, toUD60x18(TierCalculationLib.prizeCount(_tier)), tierShares);
             }
+            
         }
         return prizeSize;
+    }
+
+    /// @notice Computes the prize size with the given parameters
+    /// @param _tierPrizeTokenPerShare The prizeTokenPerShare of the Tier struct
+    /// @param _prizeTokenPerShare The global prizeTokenPerShare
+    /// @param _fractionalPrizeCount The prize count as UD60x18
+    /// @param _shares The number of shares that the tier has
+    /// @return The prize size
+    function _computePrizeSize(UD60x18 _tierPrizeTokenPerShare, UD60x18 _prizeTokenPerShare, UD60x18 _fractionalPrizeCount, uint8 _shares) internal pure returns (uint256) {
+        UD60x18 delta = _prizeTokenPerShare.sub(_tierPrizeTokenPerShare);
+        return fromUD60x18(delta.mul(toUD60x18(_shares)).div(_fractionalPrizeCount));
     }
 
     /// @notice Reclaims liquidity from tiers, starting at the highest tier

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -250,18 +250,6 @@ contract TieredLiquidityDistributor {
         return uint256(_numberOfTiers) * uint256(tierShares) + uint256(canaryShares) + uint256(reserveShares);
     }
 
-    /// @notice Consume liquidity from the given tier. Will pull from the tier, then pull from the reserve.
-    /// @param _tier The tier to consume liquidity from
-    /// @param _liquidity The amount of liquidity to consume
-    /// @return The Tier struct after consumption
-    function _consumeLiquidity(uint8 _tier, uint104 _liquidity) internal returns (Tier memory) {
-        uint8 numTiers = numberOfTiers;
-        uint8 shares = _computeShares(_tier, numTiers);
-        Tier memory tier = _getTier(_tier, numberOfTiers);
-        tier = _consumeLiquidity(tier, _tier, shares, _liquidity);
-        return tier;
-    }
-
     /// @notice Computes the number of shares for the given tier. If the tier is the canary tier, then the canary shares are returned.  Normal tier shares otherwise.
     /// @param _tier The tier to request share for
     /// @param _numTiers The number of tiers. Passed explicitly as an optimization
@@ -276,16 +264,7 @@ contract TieredLiquidityDistributor {
     /// @param _liquidity The amount of liquidity to consume
     /// @return An updated Tier struct after consumption
     function _consumeLiquidity(Tier memory _tierStruct, uint8 _tier, uint104 _liquidity) internal returns (Tier memory) {
-        return _consumeLiquidity(_tierStruct, _tier, _computeShares(_tier, numberOfTiers), _liquidity);
-    }
-
-    /// @notice Consumes liquidity from the given tier.
-    /// @param _tierStruct The tier to consume liquidity from
-    /// @param _tier The tier number
-    /// @param _shares The number of shares allocated to this tier
-    /// @param _liquidity The amount of liquidity to consume
-    /// @return An updated Tier struct after consumption
-    function _consumeLiquidity(Tier memory _tierStruct, uint8 _tier, uint8 _shares, uint104 _liquidity) internal returns (Tier memory) {
+        uint8 _shares = _computeShares(_tier, numberOfTiers);
         uint104 remainingLiquidity = uint104(_remainingTierLiquidity(_tierStruct, _shares));
         if (_liquidity > remainingLiquidity) {
             uint104 excess = _liquidity - remainingLiquidity;

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -304,15 +304,6 @@ contract TieredLiquidityDistributor {
         return _tierStruct;
     }
 
-    /// @notice Computes the remaining liquidity for the given tier
-    /// @param _tier The tier to calculate for
-    /// @return The remaining liquidity
-    function _remainingTierLiquidity(uint8 _tier) internal view returns (uint112) {
-        uint8 shares = _computeShares(_tier, numberOfTiers);
-        Tier memory tier = _getTier(_tier, numberOfTiers);
-        return _remainingTierLiquidity(tier, shares);
-    }
-
     /// @notice Computes the total liquidity available to a tier
     /// @param _tier The tier to compute the liquidity for
     /// @return The total liquidity

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -325,8 +325,7 @@ contract TieredLiquidityDistributor {
     /// @param _shares The number of shares that the tier has
     /// @return The prize size
     function _computePrizeSize(UD60x18 _tierPrizeTokenPerShare, UD60x18 _prizeTokenPerShare, UD60x18 _fractionalPrizeCount, uint8 _shares) internal pure returns (uint256) {
-        UD60x18 delta = _prizeTokenPerShare.sub(_tierPrizeTokenPerShare);
-        return fromUD60x18(delta.mul(toUD60x18(_shares)).div(_fractionalPrizeCount));
+        return fromUD60x18(_prizeTokenPerShare.sub(_tierPrizeTokenPerShare).mul(toUD60x18(_shares)).div(_fractionalPrizeCount));
     }
 
     /// @notice Reclaims liquidity from tiers, starting at the highest tier

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -330,12 +330,10 @@ contract TieredLiquidityDistributor {
         uint256 prizeSize;
         if (_prizeTokenPerShare.gt(_tierPrizeTokenPerShare)) {
             UD60x18 delta = _prizeTokenPerShare.sub(_tierPrizeTokenPerShare);
-            if (delta.unwrap() > 0) {
-                if (_tier == _numberOfTiers) {
-                    prizeSize = fromUD60x18(delta.mul(toUD60x18(canaryShares)).div(_canaryPrizeCountFractional(_numberOfTiers)));
-                } else {
-                    prizeSize = fromUD60x18(delta.mul(toUD60x18(tierShares)).div(toUD60x18(TierCalculationLib.prizeCount(_tier))));
-                }
+            if (_tier == _numberOfTiers) {
+                prizeSize = fromUD60x18(delta.mul(toUD60x18(canaryShares)).div(_canaryPrizeCountFractional(_numberOfTiers)));
+            } else {
+                prizeSize = fromUD60x18(delta.mul(toUD60x18(tierShares)).div(toUD60x18(TierCalculationLib.prizeCount(_tier))));
             }
         }
         return prizeSize;

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -12,7 +12,7 @@ import { UD2x18, ud2x18 } from "prb-math/UD2x18.sol";
 import { SD1x18, sd1x18 } from "prb-math/SD1x18.sol";
 import { TwabController } from "v5-twab-controller/TwabController.sol";
 
-import { PrizePool, ConstructorParams, InsufficientRewardsError, AlreadyClaimedPrize, DidNotWin, FeeTooLarge, SmoothingGTEOne, ContributionGTDeltaBalance, InsufficientReserve, RandomNumberIsZero, DrawNotFinished, WinnerPrizeMismatch, InvalidPrizeIndex, NoCompletedDraw, InvalidTier, SenderIsNotDrawManager } from "../src/PrizePool.sol";
+import { PrizePool, ConstructorParams, InsufficientRewardsError, AlreadyClaimedPrize, DidNotWin, FeeTooLarge, SmoothingGTEOne, ContributionGTDeltaBalance, InsufficientReserve, RandomNumberIsZero, DrawNotFinished, WinnerPrizeMismatch, InvalidPrizeIndex, NoCompletedDraw, InvalidTier, CallerNotDrawManager } from "../src/PrizePool.sol";
 import { ERC20Mintable } from "./mocks/ERC20Mintable.sol";
 
 contract PrizePoolTest is Test {
@@ -166,7 +166,7 @@ contract PrizePoolTest is Test {
 
     function testWithdrawReserve_notManager() public {
         vm.prank(address(0));
-        vm.expectRevert(abi.encodeWithSelector(SenderIsNotDrawManager.selector, address(0), address(this)));
+        vm.expectRevert(abi.encodeWithSelector(CallerNotDrawManager.selector, address(0), address(this)));
         prizePool.withdrawReserve(address(0), 1);
     }
 
@@ -332,7 +332,7 @@ contract PrizePoolTest is Test {
 
     function testCompleteAndStartNextDraw_notManager() public {
         vm.prank(address(0));
-        vm.expectRevert(abi.encodeWithSelector(SenderIsNotDrawManager.selector, address(0), address(this)));
+        vm.expectRevert(abi.encodeWithSelector(CallerNotDrawManager.selector, address(0), address(this)));
         prizePool.completeAndStartNextDraw(winningRandomNumber);
     }
 

--- a/test/PrizePool.t.sol
+++ b/test/PrizePool.t.sol
@@ -12,7 +12,7 @@ import { UD2x18, ud2x18 } from "prb-math/UD2x18.sol";
 import { SD1x18, sd1x18 } from "prb-math/SD1x18.sol";
 import { TwabController } from "v5-twab-controller/TwabController.sol";
 
-import { PrizePool, InsufficientRewardsError, AlreadyClaimedPrize, DidNotWin, FeeTooLarge, SmoothingGTEOne, ContributionGTDeltaBalance, InsufficientReserve, RandomNumberIsZero, DrawNotFinished, WinnerPrizeMismatch, InvalidPrizeIndex, NoCompletedDraw, InvalidTier } from "../src/PrizePool.sol";
+import { PrizePool, ConstructorParams, InsufficientRewardsError, AlreadyClaimedPrize, DidNotWin, FeeTooLarge, SmoothingGTEOne, ContributionGTDeltaBalance, InsufficientReserve, RandomNumberIsZero, DrawNotFinished, WinnerPrizeMismatch, InvalidPrizeIndex, NoCompletedDraw, InvalidTier, SenderIsNotDrawManager } from "../src/PrizePool.sol";
 import { ERC20Mintable } from "./mocks/ERC20Mintable.sol";
 
 contract PrizePoolTest is Test {
@@ -89,9 +89,10 @@ contract PrizePoolTest is Test {
         lastCompletedDrawStartedAt = uint64(block.timestamp + 1 days); // set draw start 1 day into future
         drawPeriodSeconds = 1 days;
 
-        prizePool = new PrizePool(
+        ConstructorParams memory params = ConstructorParams(
             prizeToken,
             twabController,
+            address(this),
             uint32(365),
             drawPeriodSeconds,
             lastCompletedDrawStartedAt,
@@ -103,16 +104,16 @@ contract PrizePoolTest is Test {
             sd1x18(0.9e18) // alpha
         );
 
-        prizePool.setManager(address(this));
+        prizePool = new PrizePool(params);
 
         vault = address(this);
     }
 
     function testConstructor_SmoothingGTEOne() public {
-        vm.expectRevert(abi.encodeWithSelector(SmoothingGTEOne.selector, 1000000000000000000));
-        new PrizePool(
+        ConstructorParams memory params = ConstructorParams(
             prizeToken,
             twabController,
+            address(this),
             uint32(365),
             drawPeriodSeconds,
             lastCompletedDrawStartedAt,
@@ -123,6 +124,8 @@ contract PrizePoolTest is Test {
             ud2x18(0.9e18),
             sd1x18(1.0e18) // smoothing
         );
+        vm.expectRevert(abi.encodeWithSelector(SmoothingGTEOne.selector, 1000000000000000000));
+        new PrizePool(params);
     }
 
     function testReserve_noRemainder() public {
@@ -159,6 +162,12 @@ contract PrizePoolTest is Test {
         */
 
         assertEq(prizePool.reserveForNextDraw(), 1.318181818181818182e18);
+    }
+
+    function testWithdrawReserve_notManager() public {
+        vm.prank(address(0));
+        vm.expectRevert(abi.encodeWithSelector(SenderIsNotDrawManager.selector, address(0), address(this)));
+        prizePool.withdrawReserve(address(0), 1);
     }
 
     function testWithdrawReserve_insuff() public {
@@ -321,6 +330,12 @@ contract PrizePoolTest is Test {
         assertEq(nextDrawId, 1);
     }
 
+    function testCompleteAndStartNextDraw_notManager() public {
+        vm.prank(address(0));
+        vm.expectRevert(abi.encodeWithSelector(SenderIsNotDrawManager.selector, address(0), address(this)));
+        prizePool.completeAndStartNextDraw(winningRandomNumber);
+    }
+
     function testCompleteAndStartNextDraw_notElapsed_atStart() public {
         vm.warp(lastCompletedDrawStartedAt);
         vm.expectRevert(abi.encodeWithSelector(DrawNotFinished.selector, lastCompletedDrawStartedAt + drawPeriodSeconds));
@@ -384,9 +399,10 @@ contract PrizePoolTest is Test {
 
     function testCompleteAndStartNextDraw_shrinkTiers() public {
         // reset prize pool at higher tiers
-        prizePool = new PrizePool(
+        ConstructorParams memory params = ConstructorParams(
             prizeToken,
             twabController,
+            address(this),
             uint32(365),
             drawPeriodSeconds,
             lastCompletedDrawStartedAt,
@@ -397,7 +413,7 @@ contract PrizePoolTest is Test {
             ud2x18(0.9e18), // claim threshold of 90%
             sd1x18(0.9e18) // alpha
         );
-        prizePool.setManager(address(this));
+        prizePool = new PrizePool(params);
 
         contribute(420e18);
         completeAndStartNextDraw(1234);

--- a/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
+++ b/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
@@ -20,7 +20,8 @@ contract TieredLiquidityDistributorWrapper is TieredLiquidityDistributor {
     }
 
     function consumeLiquidity(uint8 _tier, uint104 _liquidity) external returns (Tier memory) {
-        return _consumeLiquidity(_tier, _liquidity);
+        Tier memory _tierData = _getTier(_tier, numberOfTiers);
+        return _consumeLiquidity(_tierData, _tier, _liquidity);
     }
 
     function remainingTierLiquidity(uint8 _tier) external view returns (uint112) {

--- a/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
+++ b/test/abstract/helper/TieredLiquidityDistributorWrapper.sol
@@ -24,6 +24,9 @@ contract TieredLiquidityDistributorWrapper is TieredLiquidityDistributor {
     }
 
     function remainingTierLiquidity(uint8 _tier) external view returns (uint112) {
-        return _remainingTierLiquidity(_tier);
+        uint8 shares = _computeShares(_tier, numberOfTiers);
+        Tier memory tier = _getTier(_tier, numberOfTiers);
+        return _remainingTierLiquidity(tier, shares);
     }
+
 }

--- a/test/invariants/helpers/PrizePoolFuzzHarness.sol
+++ b/test/invariants/helpers/PrizePoolFuzzHarness.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import "forge-std/console2.sol";
 
-import { PrizePool } from "src/PrizePool.sol";
+import { PrizePool, ConstructorParams } from "src/PrizePool.sol";
 import { TwabController } from "v5-twab-controller/TwabController.sol";
 import { ERC20Mintable } from "test/mocks/ERC20Mintable.sol";
 import { UD2x18 } from "prb-math/UD2x18.sol";
@@ -20,6 +20,7 @@ contract PrizePoolFuzzHarness is CommonBase {
     uint public claimed;
 
     constructor() {
+        address drawManager = address(this);
         uint32 grandPrizePeriodDraws = 10;
         uint32 drawPeriodSeconds = 1 hours;
         uint64 nextDrawStartsAt = uint64(block.timestamp);
@@ -35,9 +36,10 @@ contract PrizePoolFuzzHarness is CommonBase {
         // arbitrary mint
         twabController.mint(address(this), 100e18);
 
-        prizePool = new PrizePool(
+        ConstructorParams memory params = ConstructorParams(
             token,
             twabController,
+            drawManager,
             grandPrizePeriodDraws,
             drawPeriodSeconds,
             nextDrawStartsAt,
@@ -48,8 +50,7 @@ contract PrizePoolFuzzHarness is CommonBase {
             claimExpansionThreshold,
             smoothing
         );
-
-        prizePool.setManager(address(this));
+        prizePool = new PrizePool(params);
     }
 
     function contributePrizeTokens(uint64 _amount) public {

--- a/test/invariants/helpers/TieredLiquidityDistributorFuzzHarness.sol
+++ b/test/invariants/helpers/TieredLiquidityDistributorFuzzHarness.sol
@@ -56,7 +56,7 @@ contract TieredLiquidityDistributorFuzzHarness is TieredLiquidityDistributor {
         // console2.log("liq ", liq);
 
         totalConsumed += liq;
-        tier_ = _consumeLiquidity(tier_, tier, shares, uint104(liq));
+        tier_ = _consumeLiquidity(tier_, tier, uint104(liq));
     }
 
 }


### PR DESCRIPTION
## Why?

The compiled size of the prize pool was exceeding the maximum set forth from EIP-170 (24.576 kB) when compiling without IR on forge.

## Changes

A list of addressed issues is available on linear: https://linear.app/pooltogether/issue/POOL-2791/reduce-prize-pool-size

## Results

The `PrizePool.sol` contract was reduced from `25.082 kB` to `23.082 kB` (a `2 kB` reduction).

## Notes

> The changes are separated into commits for each issue addressed. It will likely be easier to review the changes one commit at a time.