### PR TITLE
Fix InvalidTier check

### DIFF
--- a/src/PrizePool.sol
+++ b/src/PrizePool.sol
@@ -749,7 +749,7 @@ contract PrizePool is TieredLiquidityDistributor {
     if (_lastCompletedDrawId == 0) {
       revert NoCompletedDraw();
     }
-    if (_tier > _numberOfTiers) {
+    if (_tier >= _numberOfTiers) {
       revert InvalidTier(_tier, _numberOfTiers);
     }
 

--- a/src/abstract/TieredLiquidityDistributor.sol
+++ b/src/abstract/TieredLiquidityDistributor.sol
@@ -635,9 +635,18 @@ contract TieredLiquidityDistributor {
   }
 
   /// @notice Returns the estimated number of prizes for the given tier
+  /// @param _tier The tier to retrieve
   /// @return The estimated number of prizes
   function getTierPrizeCount(uint8 _tier) external view returns (uint32) {
     return _getTierPrizeCount(_tier, numberOfTiers);
+  }
+
+  /// @notice Returns the estimated number of prizes for the given tier and number of tiers
+  /// @param _tier The tier to retrieve
+  /// @param _numberOfTiers The number of tiers, should match the current number of tiers
+  /// @return The estimated number of prizes
+  function getTierPrizeCount(uint8 _tier, uint8 _numberOfTiers) external view returns (uint32) {
+    return _getTierPrizeCount(_tier, _numberOfTiers);
   }
 
   /// @notice Returns the number of available prizes for the given tier


### PR DESCRIPTION
The check for a valid tier was incorrect. Tiers start at 0 and the canary tier is the last tier. Any prize claim for a tier should be strictly less than the number of tiers.

- Expose method to calculate prize count for any number of tiers, not just current state. 
- Fix invalid check of tier vs number of tiers